### PR TITLE
fix for npe which occurs if returning unauthenticated from provider

### DIFF
--- a/src/main/java/com/github/leleuj/ss/oauth/client/authentication/OAuthAuthenticationProvider.java
+++ b/src/main/java/com/github/leleuj/ss/oauth/client/authentication/OAuthAuthenticationProvider.java
@@ -61,6 +61,11 @@ public final class OAuthAuthenticationProvider implements AuthenticationProvider
             return null;
         }
         
+		if (authentication.getCredentials() == null) {
+			logger.debug("authentication failed");
+			return null;
+		}
+        
         // get the OAuth credentials
         OAuthCredential credential = (OAuthCredential) authentication.getCredentials();
         logger.debug("credential : {}", credential);


### PR DESCRIPTION
if you are cancel the authentication by clicking back or abort at the provider, the credentials are not set and a npe is thrown. so check if there are authentication credentials and simply return if not.
