### PR TITLE
issue-5: Allow custom Pricipal or UserDetails

### DIFF
--- a/src/main/java/org/pac4j/springframework/security/authentication/ClientAuthenticationToken.java
+++ b/src/main/java/org/pac4j/springframework/security/authentication/ClientAuthenticationToken.java
@@ -1,5 +1,5 @@
 /*
-  Copyright 2012 - 2014 Jerome Leleu
+  Copyright 2012 - 2015 Jerome Leleu
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -21,44 +21,63 @@ import org.pac4j.core.credentials.Credentials;
 import org.pac4j.core.profile.UserProfile;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 
 /**
- * This token represents a credentials ({@link Credentials}), a client name and an user profile ( {@link UserProfile}).
- * 
+ * This token represents a credentials: {@link #credentials}, a client name: {@link #clientName},
+ * a user profile: {@link #userProfile} and an optional user (details): {@link #userDetails}.
+ *
  * @author Jerome Leleu
  * @since 1.0.0
  */
 public final class ClientAuthenticationToken extends AbstractAuthenticationToken {
-    
+
     private static final long serialVersionUID = 8303047831754762526L;
-    
+
     private final Credentials credentials;
-    
+
     private UserProfile userProfile = null;
-    
+
     private final String clientName;
-    
+
+    private final UserDetails userDetails;
+
     public ClientAuthenticationToken(final Credentials credentials, final String clientName) {
         super(null);
         this.credentials = credentials;
         this.clientName = clientName;
+        this.userDetails = null;
         setAuthenticated(false);
     }
-    
+
     public ClientAuthenticationToken(final Credentials credentials, final String clientName,
-                                     final UserProfile userProfile,
-                                     final Collection<? extends GrantedAuthority> authorities) {
+            final UserProfile userProfile,
+            final Collection<? extends GrantedAuthority> authorities) {
         super(authorities);
         this.credentials = credentials;
         this.clientName = clientName;
         this.userProfile = userProfile;
+        this.userDetails = null;
         setAuthenticated(true);
     }
-    
+
+    public ClientAuthenticationToken(final Credentials credentials, final String clientName,
+            final UserProfile userProfile, final Collection<? extends GrantedAuthority> authorities,
+            final UserDetails userDetails) {
+        super(authorities);
+        this.credentials = credentials;
+        this.clientName = clientName;
+        this.userProfile = userProfile;
+        this.userDetails = userDetails;
+        setAuthenticated(true);
+    }
+
+    @Override
     public Object getCredentials() {
         return this.credentials;
     }
-    
+
+    @Override
     public Object getPrincipal() {
         if (this.userProfile != null) {
             return this.userProfile.getTypedId();
@@ -66,12 +85,16 @@ public final class ClientAuthenticationToken extends AbstractAuthenticationToken
             return null;
         }
     }
-    
+
     public UserProfile getUserProfile() {
         return this.userProfile;
     }
-    
+
     public String getClientName() {
         return this.clientName;
+    }
+
+    public UserDetails getUserDetails() {
+        return this.userDetails;
     }
 }

--- a/src/main/java/org/pac4j/springframework/security/web/ClientAuthenticationFilter.java
+++ b/src/main/java/org/pac4j/springframework/security/web/ClientAuthenticationFilter.java
@@ -1,5 +1,5 @@
 /*
-  Copyright 2012 - 2014 Jerome Leleu
+  Copyright 2012 - 2015 Jerome Leleu
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -39,47 +39,47 @@ import org.springframework.security.web.authentication.AbstractAuthenticationPro
  * This filter handles callbacks after authentication from the provider. It listens HTTP requests on /j_spring_pac4j_security_check by
  * default or whatever suffix url you can define by constructor. An
  * {@link org.pac4j.springframework.security.authentication.ClientAuthenticationToken} is created to finish the authentication process.
- * 
+ *
  * @author Jerome Leleu
  * @since 1.0.0
  */
 public final class ClientAuthenticationFilter extends AbstractAuthenticationProcessingFilter {
-    
+
     private static final Logger logger = LoggerFactory.getLogger(ClientAuthenticationFilter.class);
-    
+
     private Clients clients;
-    
+
     /**
      * Define the suffix url on which the filter will listen for HTTP requests.
-     * 
-     * @param suffixUrl
+     *
+     * @param suffixUrl the suffix url
      */
     public ClientAuthenticationFilter(final String suffixUrl) {
         super(suffixUrl);
     }
-    
+
     protected ClientAuthenticationFilter() {
         super("/j_spring_pac4j_security_check");
     }
-    
+
     @Override
     public void afterPropertiesSet() {
         super.afterPropertiesSet();
         CommonHelper.assertNotNull("clients", this.clients);
         this.clients.init();
     }
-    
+
     @Override
     @SuppressWarnings("rawtypes")
     public Authentication attemptAuthentication(final HttpServletRequest request, final HttpServletResponse response)
-        throws AuthenticationException, IOException, ServletException {
-        
+            throws AuthenticationException, IOException, ServletException {
+
         // context
         final WebContext context = new J2EContext(request, response);
-        
+
         // get the right client
         final Client client = this.clients.findClient(context);
-        
+
         // get credentials
         Credentials credentials;
         try {
@@ -99,17 +99,17 @@ public final class ClientAuthenticationFilter extends AbstractAuthenticationProc
         // set details
         token.setDetails(this.authenticationDetailsSource.buildDetails(request));
         logger.debug("token : {}", token);
-        
+
         // authenticate
         final Authentication authentication = getAuthenticationManager().authenticate(token);
         logger.debug("authentication : {}", authentication);
         return authentication;
     }
-    
+
     public Clients getClients() {
         return this.clients;
     }
-    
+
     public void setClients(final Clients clients) {
         this.clients = clients;
     }


### PR DESCRIPTION
Now a `UserDetails` is embedded in the `ClientAuthenticationToken`, it's a user identity (get through the `UserDetailsService`) in addition to the pac4j one. The use case is to retrieve a local user matching the remote (pac4j) one.

Some formatting as well.