### PR TITLE
Return UserDetails object for ClientAuthenticationToken.getPrincipal() as first preference.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <artifactId>spring-security-pac4j</artifactId>
     <packaging>jar</packaging>
     <name>Spring Security pac4j</name>
-    <version>1.2.6-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
     <description>Java multi protocols (CAS, OAuth, OpenID, HTTP...) client for Spring Security</description>
     <url>https://github.com/leleuj/spring-security-pac4j</url>
 

--- a/src/main/java/org/pac4j/springframework/security/authentication/ClientAuthenticationToken.java
+++ b/src/main/java/org/pac4j/springframework/security/authentication/ClientAuthenticationToken.java
@@ -79,6 +79,8 @@ public final class ClientAuthenticationToken extends AbstractAuthenticationToken
 
     @Override
     public Object getPrincipal() {
+    	if (this.userDetails != null)
+    		return this.userDetails;
         if (this.userProfile != null) {
             return this.userProfile.getTypedId();
         } else {

--- a/src/main/java/org/pac4j/springframework/security/authentication/ClientAuthenticationToken.java
+++ b/src/main/java/org/pac4j/springframework/security/authentication/ClientAuthenticationToken.java
@@ -79,8 +79,8 @@ public final class ClientAuthenticationToken extends AbstractAuthenticationToken
 
     @Override
     public Object getPrincipal() {
-    	if (this.userDetails != null)
-    		return this.userDetails;
+        if (this.userDetails != null)
+            return this.userDetails;
         if (this.userProfile != null) {
             return this.userProfile.getTypedId();
         } else {


### PR DESCRIPTION
Spring Security API JavaDoc for Authentication.getPrincipal() has a paragraph stating:

"The AuthenticationManager implementation will often return an Authentication containing richer information as the principal for use by the application. Many of the authentication providers will create a UserDetails object as the principal."

Currently, ClientAuthentication.getPrincipal() returns UserProfile.getTypeId() if present. This pull request will return the supplied UserDetails object as first preference.