### PR TITLE
Adding a test framework and implementation of AuthenticationManager for #3.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,18 @@
     <description>Java multi protocols (CAS, OAuth, OpenID, HTTP...) client for Spring Security</description>
     <url>https://github.com/pac4j/spring-security-pac4j</url>
 
+    <properties>
+        <cglib.version>3.1</cglib.version>
+        <groovy.version>2.4.4</groovy.version>
+        <spock.version>1.0-groovy-2.4</spock.version>
+        <objenesis.version>2.2</objenesis.version>
+        <slf4j.version>1.7.2</slf4j.version>
+        <logback.version>1.1.3</logback.version>
+        <spring.security.version>3.2.7.RELEASE</spring.security.version>
+        <servlet.version>2.5</servlet.version>
+        <pac4j.version>1.7.0</pac4j.version>
+    </properties>
+
     <licenses>
         <license>
             <name>The Apache Software License, Version 2.0</name>
@@ -57,23 +69,61 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-web</artifactId>
-            <version>3.2.7.RELEASE</version>
+            <version>${spring.security.version}</version>
         </dependency>
 		<dependency>
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-config</artifactId>
-			<version>3.2.7.RELEASE</version>
+			<version>${spring.security.version}</version>
 		</dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>servlet-api</artifactId>
-            <version>2.5</version>
+            <version>${servlet.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.pac4j</groupId>
             <artifactId>pac4j-core</artifactId>
-            <version>1.7.0</version>
+            <version>${pac4j.version}</version>
+        </dependency>
+
+        <!--Needed by Spring pieces-->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback.version}</version>
+        </dependency>
+
+        <!--Needed for Spock framework-->
+        <dependency>
+            <groupId>org.spockframework</groupId>
+            <artifactId>spock-core</artifactId>
+            <version>${spock.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-all</artifactId>
+            <version>${groovy.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>cglib</groupId>
+            <artifactId>cglib-nodep</artifactId>
+            <version>${cglib.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.objenesis</groupId>
+            <artifactId>objenesis</artifactId>
+            <version>${objenesis.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -119,6 +169,31 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+
+            <!--Needed for Spock Framework-->
+            <plugin>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
+                <version>1.5</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.6</version>
+                <configuration>
+                    <useFile>false</useFile>
+                    <includes>
+                        <include>**/*Spec.java</include>
+                    </includes>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/org/pac4j/springframework/security/authentication/ClientProviderManager.java
+++ b/src/main/java/org/pac4j/springframework/security/authentication/ClientProviderManager.java
@@ -1,0 +1,212 @@
+package org.pac4j.springframework.security.authentication;
+
+import java.util.Set;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.MessageSource;
+import org.springframework.context.MessageSourceAware;
+import org.springframework.context.support.MessageSourceAccessor;
+import org.springframework.security.authentication.*;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.CredentialsContainer;
+import org.springframework.security.core.SpringSecurityMessageSource;
+import org.springframework.util.Assert;
+
+/**
+ * Modeled after Spring Security's {@link ProviderManager}. Provides an implementation of
+ * {@link AuthenticationManager} conducive (but not exclusive) to Pac4j authentication
+ * mechanisms.
+ *
+ * @author Jacob Severson
+ * @since  1.3.0
+ */
+public class ClientProviderManager implements AuthenticationManager, MessageSourceAware, InitializingBean {
+
+    private final Set<AuthenticationProvider> providers;
+    private final AuthenticationManager parent;
+    private final boolean eraseCredentialsAfterAuthentication;
+
+    protected MessageSourceAccessor messages = SpringSecurityMessageSource.getAccessor();
+    private AuthenticationEventPublisher eventPublisher = new NullEventPublisher();
+
+    /**
+     * Constructs a ClientProviderManager with no parent {@link AuthenticationManager} erasing of
+     * credentials after successful authentication is turned on.
+     *
+     * @param providers providers used to attempt authentication
+     */
+    public ClientProviderManager(Set<AuthenticationProvider> providers) {
+        this(providers, null);
+    }
+
+    /**
+     * Constructs a ClientProviderManager with a parent {@link AuthenticationManager}. Authentication
+     * will be delegated to the parent if the incoming {@link Authentication} is not compatible with
+     * any of the providers or if the compatible provider failed. Erasing of credentials after successful
+     * authentication is turned on.
+     *
+     * @param providers providers used to attempt authentication
+     * @param parent    parent AuthenticationManager to try authentication upon an unsuccessful attempt by this one
+     */
+    public ClientProviderManager(Set<AuthenticationProvider> providers,
+                                 AuthenticationManager parent) {
+        this(providers, parent, true);
+    }
+
+    /**
+     * Constructs a ClientProviderManager and allows control over erasing of credentials. Upon successful
+     * authentication if eraseCredentialsAfterAuthentication is set to true, the "credentials" held in
+     * the authenticated {@link Authentication} object are removed before being placed into the
+     * security context.
+     *
+     * @param providers                             providers used to attempt authentication
+     * @param parent                                parent AuthenticationManager to try authentication upon an
+     *                                              unsuccessful attempt by this one
+     * @param eraseCredentialsAfterAuthentication   dictates whether the credentials of the authenticated object
+     *                                              are removed
+     */
+    public ClientProviderManager(Set<AuthenticationProvider> providers,
+                                 AuthenticationManager parent,
+                                 boolean eraseCredentialsAfterAuthentication) {
+        this.providers = providers;
+        this.parent = parent;
+        this.eraseCredentialsAfterAuthentication = eraseCredentialsAfterAuthentication;
+    }
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        AuthenticationException lastException = null;
+        Authentication result = null;
+
+        for (AuthenticationProvider provider : providers) {
+            if (!provider.supports(authentication.getClass())) {
+                continue;
+            }
+
+            try {
+                result = provider.authenticate(authentication);
+
+                if (result != null) {
+                    copyDetails(authentication, result);
+                    break;
+                }
+            }
+            catch (AccountStatusException e) {
+                eventPublisher.publishAuthenticationFailure(e, authentication);
+                throw e;
+            }
+            catch (InternalAuthenticationServiceException e) {
+                eventPublisher.publishAuthenticationFailure(e, authentication);
+                throw e;
+            }
+            catch (AuthenticationException e) {
+                lastException = e;
+            }
+        }
+
+        if (result == null && parent != null) {
+            try {
+                result = parent.authenticate(authentication);
+            }
+            catch (ProviderNotFoundException e) {
+                // No-op. If authentication with this manager failed
+                // with an exception it could get squashed by this one
+                // even though we may expect this one to be thrown. If this
+                // exception is the ultimate culprit it will get thrown at the end
+                // of this method.
+            }
+            catch (AuthenticationException e) {
+                lastException = e;
+            }
+        }
+
+        if (result != null) {
+            if (eraseCredentialsAfterAuthentication) {
+                result = eraseCredentials(result);
+            }
+            eventPublisher.publishAuthenticationSuccess(result);
+            return result;
+        }
+
+        if (lastException == null) {
+            lastException = new ProviderNotFoundException(messages.getMessage(
+                    "ProviderManager.providerNotFound",
+                    new Object[] { authentication.getName() },
+                    "No AuthenticationProvider found for {0}"));
+        }
+
+        eventPublisher.publishAuthenticationFailure(lastException, authentication);
+        throw lastException;
+    }
+
+    /**
+     * Copies details of the authentication request into the authenticated object.
+     *
+     * @param source    Authentication created from a request to authenticate
+     * @param dest      Authentication created by successful authentication
+     *
+     */
+    private void copyDetails(Authentication source, Authentication dest) {
+
+        if ((dest instanceof AbstractAuthenticationToken) && (dest.getDetails() == null)) {
+            AbstractAuthenticationToken token = (AbstractAuthenticationToken) dest;
+
+            token.setDetails(source.getDetails());
+        }
+    }
+
+    /**
+     * Erases the credentials of the {@link Authentication} object depending on the
+     * subtype. This method takes into account the {@link ClientAuthenticationToken}
+     * type which cannot have credentials erased in the default {@link ProviderManager}.
+     *
+     * @param authentication    authenticated Authentication object
+     * @return                  the Authentication object with erased credentials
+     */
+    private Authentication eraseCredentials(Authentication authentication) {
+
+        if (authentication instanceof ClientAuthenticationToken) {
+            ClientAuthenticationToken clientAuthenticationToken = ((ClientAuthenticationToken)authentication);
+            return new ClientAuthenticationToken (
+                    null,
+                    clientAuthenticationToken.getClientName(),
+                    clientAuthenticationToken.getUserProfile(),
+                    clientAuthenticationToken.getAuthorities(),
+                    clientAuthenticationToken.getUserDetails()
+            );
+
+        } else if (authentication instanceof CredentialsContainer) {
+            ((AbstractAuthenticationToken) authentication).eraseCredentials();
+            return authentication;
+
+        }
+
+        // Not expecting this, but just in case it is an implementation that
+        // is neither Pac4j specific nor of type CredentialsContainer
+        return authentication;
+    }
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        if (parent == null && providers.isEmpty()) {
+            throw new IllegalArgumentException("At least one parent AuthenticationManager or " +
+                    "AuthenticationProvider is required.");
+        }
+    }
+
+    @Override
+    public void setMessageSource(MessageSource messageSource) {
+        this.messages = new MessageSourceAccessor(messageSource);
+    }
+
+    public void setAuthenticationEventPublisher(AuthenticationEventPublisher eventPublisher) {
+        Assert.notNull(eventPublisher, "AuthenticationEventPublisher cannot be null");
+        this.eventPublisher = eventPublisher;
+    }
+
+    private static final class NullEventPublisher implements AuthenticationEventPublisher {
+        public void publishAuthenticationFailure(AuthenticationException exception, Authentication authentication) {}
+        public void publishAuthenticationSuccess(Authentication authentication) {}
+    }
+}

--- a/src/test/groovy/org/pac4j/springframework/security/authentication/ClientProviderManagerSpec.groovy
+++ b/src/test/groovy/org/pac4j/springframework/security/authentication/ClientProviderManagerSpec.groovy
@@ -1,0 +1,337 @@
+package org.pac4j.springframework.security.authentication
+
+import org.pac4j.core.credentials.Credentials
+import org.pac4j.core.profile.UserProfile
+import org.springframework.security.authentication.*
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.userdetails.UserDetails
+import org.springframework.security.web.authentication.rememberme.RememberMeAuthenticationException
+import org.springframework.security.web.authentication.session.SessionAuthenticationException
+import spock.lang.Specification
+
+class ClientProviderManagerSpec extends Specification {
+
+    AuthenticationProvider providerMock
+    AuthenticationManager parentAuthenticationManagerMock
+    AuthenticationEventPublisher eventPublisherMock
+
+    void setup() {
+        providerMock = Mock(AuthenticationProvider)
+        parentAuthenticationManagerMock = Mock(AuthenticationManager)
+        eventPublisherMock = Mock(AuthenticationEventPublisher)
+    }
+
+    void 'a valid ClientAuthenticationToken is authenticated by a provider'() {
+        given:
+        ClientProviderManager manager = new ClientProviderManager([providerMock] as Set)
+        manager.setAuthenticationEventPublisher(eventPublisherMock)
+
+        when:
+        Authentication result = manager.authenticate(buildClientToken())
+
+        then:
+        1 * providerMock.supports(ClientAuthenticationToken) >> true
+        1 * providerMock.authenticate(_ as Authentication) >> buildClientToken()
+        1 * eventPublisherMock.publishAuthenticationSuccess(_ as Authentication)
+        0 * _
+        result instanceof ClientAuthenticationToken
+        ((ClientAuthenticationToken) result).userDetails
+        ((ClientAuthenticationToken) result).userProfile
+        ((ClientAuthenticationToken) result).clientName
+    }
+
+    void 'a valid and authenticated ClientAuthenticationToken gets credentials erased if flag is set true'() {
+        given:
+        ClientProviderManager manager = new ClientProviderManager([providerMock] as Set)
+        manager.setAuthenticationEventPublisher(eventPublisherMock)
+
+        when:
+        Authentication result = manager.authenticate(buildClientToken())
+
+        then:
+        1 * providerMock.supports(ClientAuthenticationToken) >> true
+        1 * providerMock.authenticate(_ as Authentication) >> buildClientToken()
+        1 * eventPublisherMock.publishAuthenticationSuccess(_ as Authentication)
+        0 * _
+        !result.getCredentials()
+    }
+
+    void 'a valid and authenticated ClientAuthenticationToken does not erase credentials if flag is set false'() {
+        given:
+        ClientProviderManager manager = new ClientProviderManager([providerMock] as Set, null, false)
+        manager.setAuthenticationEventPublisher(eventPublisherMock)
+
+        when:
+        Authentication result = manager.authenticate(buildClientToken())
+
+        then:
+        1 * providerMock.supports(ClientAuthenticationToken) >> true
+        1 * providerMock.authenticate(_ as Authentication) >> buildClientToken()
+        1 * eventPublisherMock.publishAuthenticationSuccess(_ as Authentication)
+        0 * _
+        result.getCredentials()
+    }
+
+    void 'attempt at authentication causes an AccountStatusException'() {
+        given:
+        ClientProviderManager manager = new ClientProviderManager([providerMock] as Set, null, false)
+        manager.setAuthenticationEventPublisher(eventPublisherMock)
+
+        when:
+        manager.authenticate(buildClientToken())
+
+        then:
+        1 * providerMock.supports(ClientAuthenticationToken) >> true
+        1 * providerMock.authenticate(_ as Authentication) >> {
+            throw new CredentialsExpiredException("test")
+        }
+        thrown(AccountStatusException)
+        1 * eventPublisherMock.publishAuthenticationFailure(_ as AccountStatusException, _ as Authentication)
+        0 * _
+    }
+
+    void 'attempt at authentication causes an InternalAuthenticationServiceException'() {
+        given:
+        ClientProviderManager manager = new ClientProviderManager([providerMock] as Set, null, false)
+        manager.setAuthenticationEventPublisher(eventPublisherMock)
+
+        when:
+        manager.authenticate(buildClientToken())
+
+        then:
+        1 * providerMock.supports(ClientAuthenticationToken) >> true
+        1 * providerMock.authenticate(_ as Authentication) >> {
+            throw new InternalAuthenticationServiceException("test")
+        }
+        thrown(InternalAuthenticationServiceException)
+        1 * eventPublisherMock.publishAuthenticationFailure(_ as InternalAuthenticationServiceException,
+                                                            _ as Authentication)
+        0 * _
+    }
+
+    void 'attempt at authentication causes an unexpected AuthenticationException'() {
+        given:
+        ClientProviderManager manager = new ClientProviderManager([providerMock] as Set, null, false)
+        manager.setAuthenticationEventPublisher(eventPublisherMock)
+
+        when:
+        manager.authenticate(buildClientToken())
+
+        then:
+        1 * providerMock.supports(ClientAuthenticationToken) >> true
+        1 * providerMock.authenticate(_ as Authentication) >> {
+            throw new  SessionAuthenticationException("test")
+        }
+        thrown(SessionAuthenticationException)
+        1 * eventPublisherMock.publishAuthenticationFailure(_ as SessionAuthenticationException, _ as Authentication)
+        0 * _
+    }
+
+    void 'successful auth via parent manager when no valid providers are given to ClientAuthenticationProvider'() {
+        given:
+        ClientProviderManager manager = new ClientProviderManager([providerMock] as Set,
+                parentAuthenticationManagerMock)
+        manager.setAuthenticationEventPublisher(eventPublisherMock)
+
+        when:
+        Authentication result = manager.authenticate(buildClientToken())
+
+        then:
+        1 * providerMock.supports(ClientAuthenticationToken) >> false
+        1 * parentAuthenticationManagerMock.authenticate(_ as Authentication) >> buildClientToken()
+        1 * eventPublisherMock.publishAuthenticationSuccess(_ as Authentication)
+        0 * _
+        result instanceof ClientAuthenticationToken
+        ((ClientAuthenticationToken) result).userDetails
+        ((ClientAuthenticationToken) result).userProfile
+        ((ClientAuthenticationToken) result).clientName
+    }
+
+    void 'successful auth via parent manager when no providers are given to ClientAuthenticationProvider'() {
+        given:
+        ClientProviderManager manager = new ClientProviderManager([] as Set,
+                parentAuthenticationManagerMock)
+        manager.setAuthenticationEventPublisher(eventPublisherMock)
+
+        when:
+        Authentication result = manager.authenticate(buildClientToken())
+
+        then:
+        1 * parentAuthenticationManagerMock.authenticate(_ as Authentication) >> buildClientToken()
+        1 * eventPublisherMock.publishAuthenticationSuccess(_ as Authentication)
+        0 * _
+        result instanceof ClientAuthenticationToken
+        ((ClientAuthenticationToken) result).userDetails
+        ((ClientAuthenticationToken) result).userProfile
+        ((ClientAuthenticationToken) result).clientName
+    }
+
+    void 'successful auth via parent manager after unsuccessful provider auth with no exceptions'() {
+        given:
+        ClientProviderManager manager = new ClientProviderManager([providerMock] as Set,
+                parentAuthenticationManagerMock)
+        manager.setAuthenticationEventPublisher(eventPublisherMock)
+
+        when:
+        Authentication result = manager.authenticate(buildClientToken())
+
+        then:
+        1 * providerMock.supports(ClientAuthenticationToken) >> true
+        1 * providerMock.authenticate(_ as Authentication) >> null
+        1 * parentAuthenticationManagerMock.authenticate(_ as Authentication) >> buildClientToken()
+        1 * eventPublisherMock.publishAuthenticationSuccess(_ as Authentication)
+        0 * _
+        result instanceof ClientAuthenticationToken
+        ((ClientAuthenticationToken) result).userDetails
+        ((ClientAuthenticationToken) result).userProfile
+        ((ClientAuthenticationToken) result).clientName
+    }
+
+    void 'successful auth via parent manager after unsuccessful provider auth with exception'() {
+        given:
+        ClientProviderManager manager = new ClientProviderManager([providerMock] as Set,
+                parentAuthenticationManagerMock)
+        manager.setAuthenticationEventPublisher(eventPublisherMock)
+
+        when:
+        Authentication result = manager.authenticate(buildClientToken())
+
+        then:
+        1 * providerMock.supports(ClientAuthenticationToken) >> true
+        1 * providerMock.authenticate(_ as Authentication) >> {
+            throw new RememberMeAuthenticationException("test")
+        }
+        1 * parentAuthenticationManagerMock.authenticate(_ as Authentication) >> buildClientToken()
+        1 * eventPublisherMock.publishAuthenticationSuccess(_ as Authentication)
+        0 * _
+        result instanceof ClientAuthenticationToken
+        ((ClientAuthenticationToken) result).userDetails
+        ((ClientAuthenticationToken) result).userProfile
+        ((ClientAuthenticationToken) result).clientName
+    }
+
+    void 'auth via parent manager that causes a ProviderNotFoundException'() {
+        given:
+        ClientProviderManager manager = new ClientProviderManager([] as Set,
+                parentAuthenticationManagerMock)
+        manager.setAuthenticationEventPublisher(eventPublisherMock)
+
+        when:
+        manager.authenticate(buildClientToken())
+
+        then:
+        1 * parentAuthenticationManagerMock.authenticate(_ as Authentication) >> {
+            throw new ProviderNotFoundException("test")
+        }
+        1 * eventPublisherMock.publishAuthenticationFailure(_ as ProviderNotFoundException, _ as Authentication)
+        0 * _
+        thrown(ProviderNotFoundException)
+    }
+
+    void 'auth via parent manager that causes unexpected AuthenticationException'() {
+        given:
+        ClientProviderManager manager = new ClientProviderManager([] as Set,
+                parentAuthenticationManagerMock)
+        manager.setAuthenticationEventPublisher(eventPublisherMock)
+
+        when:
+        manager.authenticate(buildClientToken())
+
+        then:
+        1 * parentAuthenticationManagerMock.authenticate(_ as Authentication) >> {
+            throw new InsufficientAuthenticationException("test")
+        }
+        1 * eventPublisherMock.publishAuthenticationFailure(_ as InsufficientAuthenticationException,
+                                                            _ as Authentication)
+        0 * _
+        thrown(InsufficientAuthenticationException)
+    }
+
+    void 'auth via parent manager that causes a ProviderNotFoundException when auth fails but no exception thrown'() {
+        given:
+        ClientProviderManager manager = new ClientProviderManager([] as Set,
+                parentAuthenticationManagerMock)
+        manager.setAuthenticationEventPublisher(eventPublisherMock)
+
+        when:
+        manager.authenticate(buildClientToken())
+
+        then:
+        1 * parentAuthenticationManagerMock.authenticate(_ as Authentication) >> null
+        1 * eventPublisherMock.publishAuthenticationFailure(_ as ProviderNotFoundException, _ as Authentication)
+        0 * _
+        thrown(ProviderNotFoundException)
+    }
+
+    void 'a valid non-client token is authenticated by a provider'() {
+        given:
+        UsernamePasswordAuthenticationToken sourceTokenMock = Mock(UsernamePasswordAuthenticationToken)
+        UsernamePasswordAuthenticationToken destTokenMock = Mock(UsernamePasswordAuthenticationToken)
+        ClientProviderManager manager = new ClientProviderManager([providerMock] as Set)
+        manager.setAuthenticationEventPublisher(eventPublisherMock)
+
+        when:
+        Authentication result = manager.authenticate(sourceTokenMock)
+
+        then:
+        1 * providerMock.supports(_) >> true
+        1 * providerMock.authenticate(_ as Authentication) >> destTokenMock
+        1 * eventPublisherMock.publishAuthenticationSuccess(_ as Authentication)
+        1 * destTokenMock.getDetails()
+        1 * sourceTokenMock.getDetails() >> {
+            return Stub(UserDetails)
+        }
+        1 * destTokenMock.setDetails(_ as UserDetails)
+        1 * destTokenMock.eraseCredentials()
+        0 * _
+        result instanceof UsernamePasswordAuthenticationToken
+    }
+
+    void 'a valid, authenticated, non-client token does not erase credentials if flag is set false'() {
+        given:
+        UsernamePasswordAuthenticationToken sourceTokenMock = Mock(UsernamePasswordAuthenticationToken)
+        UsernamePasswordAuthenticationToken destTokenMock = Mock(UsernamePasswordAuthenticationToken)
+        ClientProviderManager manager = new ClientProviderManager([providerMock] as Set,
+                null,
+                false
+                                                                  )
+        manager.setAuthenticationEventPublisher(eventPublisherMock)
+
+        when:
+        Authentication result = manager.authenticate(sourceTokenMock)
+
+        then:
+        1 * providerMock.supports(_) >> true
+        1 * providerMock.authenticate(_ as Authentication) >> destTokenMock
+        1 * eventPublisherMock.publishAuthenticationSuccess(_ as Authentication)
+        1 * destTokenMock.getDetails()
+        1 * sourceTokenMock.getDetails() >> {
+            return Stub(UserDetails)
+        }
+        1 * destTokenMock.setDetails(_ as UserDetails)
+        0 * _
+        result instanceof UsernamePasswordAuthenticationToken
+    }
+
+    private static ClientAuthenticationToken buildClientToken() {
+        return new ClientAuthenticationToken (
+                buildClientCredentials(),
+                'testClient',
+                buildUserProfile(),
+                [],
+                buildUserDetails()
+        )
+    }
+
+    private static Credentials buildClientCredentials() {
+        return new TestCredentials()
+    }
+
+    private static UserProfile buildUserProfile() {
+        return new UserProfile()
+    }
+
+    private static UserDetails buildUserDetails() {
+        return new TestUserDetails()
+    }
+}

--- a/src/test/groovy/org/pac4j/springframework/security/authentication/TestCredentials.groovy
+++ b/src/test/groovy/org/pac4j/springframework/security/authentication/TestCredentials.groovy
@@ -1,0 +1,8 @@
+package org.pac4j.springframework.security.authentication
+
+import org.pac4j.core.credentials.Credentials
+
+/**
+ * Stub implementation of Pac4j's {@link Credentials} for testing.
+ */
+class TestCredentials extends Credentials {}

--- a/src/test/groovy/org/pac4j/springframework/security/authentication/TestUserDetails.groovy
+++ b/src/test/groovy/org/pac4j/springframework/security/authentication/TestUserDetails.groovy
@@ -1,0 +1,45 @@
+package org.pac4j.springframework.security.authentication
+
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.userdetails.UserDetails
+
+/**
+ * Stub implementation of Spring Security's {@link UserDetails} for testing.
+ */
+class TestUserDetails implements UserDetails {
+
+    @Override
+    Collection<? extends GrantedAuthority> getAuthorities() {
+        return null
+    }
+
+    @Override
+    String getPassword() {
+        return null
+    }
+
+    @Override
+    String getUsername() {
+        return null
+    }
+
+    @Override
+    boolean isAccountNonExpired() {
+        return true
+    }
+
+    @Override
+    boolean isAccountNonLocked() {
+        return true
+    }
+
+    @Override
+    boolean isCredentialsNonExpired() {
+        return true
+    }
+
+    @Override
+    boolean isEnabled() {
+        return true
+    }
+}


### PR DESCRIPTION
Adding an implementation of `AuthenticationManager` to support some
Pac4j-specific authentication mechanisms. Specifically, erasing
of credentials is not possible currently since Pac4j credentials
do not implement Spring Security's `CredentialsContainer`. Having
an implementation of `AuthenticationManager` that knows how to deal
with `ClientAuthenticationToken`s keeps credential erasing behavior
in the correct abstraction while not requiring it. It also gives
us an extension point for more Pac4j-specific functionality at
this level in the future.

* Added the implementation of `AuthenticationManager`

* Added Spock framework for unit testing