### PR TITLE
Align spring-security-pac4j with pac4j version 1.9.0-SNAPSHOT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: false
 script: "mvn package --settings travis/settings.xml"
 
 jdk:
-  - oraclejdk7
+  - oraclejdk8
 
 env:
   global:

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <spring.security.version>4.0.3.RELEASE</spring.security.version>
         <spring.version>4.2.2.RELEASE</spring.version>
         <servlet.version>3.0.1</servlet.version>
-        <pac4j.version>1.8.8-SNAPSHOT</pac4j.version>
+        <pac4j.version>1.9.0-SNAPSHOT</pac4j.version>
         <powermockito.version>1.6.3</powermockito.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -54,8 +54,8 @@
     </developers>
 
     <properties>
-        <spring.security.version>4.0.3.RELEASE</spring.security.version>
-        <spring.version>4.2.2.RELEASE</spring.version>
+        <spring.security.version>4.0.4.RELEASE</spring.security.version>
+        <spring.version>4.2.5.RELEASE</spring.version>
         <servlet.version>3.0.1</servlet.version>
         <pac4j.version>1.9.0-SNAPSHOT</pac4j.version>
         <powermockito.version>1.6.3</powermockito.version>
@@ -211,6 +211,27 @@
 						</supportedProjectTypes>
 					</configuration>
 				</plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>findbugs-maven-plugin</artifactId>
+                    <version>3.0.3</version>
+                    <configuration>
+                        <effort>Low</effort> <!-- Max -->
+                        <threshold>Max</threshold> <!-- Medium Low -->
+                        <failOnError>true</failOnError>
+                        <excludeFilterFile>findbugs-exclude.xml</excludeFilterFile>
+                        <includeTests>true</includeTests>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>run-findbugs</id>
+                            <phase>compile</phase>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
 			</plugins>
 		</pluginManagement>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <properties>
         <spring.security.version>4.0.4.RELEASE</spring.security.version>
         <spring.version>4.2.5.RELEASE</spring.version>
-        <servlet.version>3.0.1</servlet.version>
+        <servlet.version>3.1.0</servlet.version>
         <pac4j.version>1.9.0-SNAPSHOT</pac4j.version>
         <powermockito.version>1.6.3</powermockito.version>
     </properties>

--- a/src/main/java/org/pac4j/springframework/security/authentication/ClientAuthenticationProvider.java
+++ b/src/main/java/org/pac4j/springframework/security/authentication/ClientAuthenticationProvider.java
@@ -22,8 +22,10 @@ import org.pac4j.core.client.Client;
 import org.pac4j.core.client.Clients;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.credentials.Credentials;
+import org.pac4j.core.exception.RequiresHttpAction;
 import org.pac4j.core.profile.UserProfile;
 import org.pac4j.core.util.CommonHelper;
+import org.pac4j.springframework.security.exception.AuthenticationCredentialsException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
@@ -75,7 +77,12 @@ public final class ClientAuthenticationProvider implements AuthenticationProvide
         final Client client = this.clients.findClient(clientName);
         // get the user profile
         final WebContext context = token.getContext();
-        final UserProfile userProfile = client.getUserProfile(credentials, context);
+        UserProfile userProfile = null;
+        try {
+            userProfile = client.getUserProfile(credentials, context);
+        } catch (RequiresHttpAction requiresHttpAction) {
+            throw new AuthenticationCredentialsException(requiresHttpAction.getMessage(), requiresHttpAction);
+        }
         logger.debug("userProfile: {}", userProfile);
 
         // by default, no authorities

--- a/src/main/java/org/pac4j/springframework/security/authentication/ClientAuthenticationProvider.java
+++ b/src/main/java/org/pac4j/springframework/security/authentication/ClientAuthenticationProvider.java
@@ -81,7 +81,8 @@ public final class ClientAuthenticationProvider implements AuthenticationProvide
         try {
             userProfile = client.getUserProfile(credentials, context);
         } catch (RequiresHttpAction requiresHttpAction) {
-            throw new AuthenticationCredentialsException(requiresHttpAction.getMessage(), requiresHttpAction);
+            logger.debug("HTTP action required", requiresHttpAction.getMessage());
+            return null;
         }
         logger.debug("userProfile: {}", userProfile);
 

--- a/src/main/java/org/pac4j/springframework/security/authentication/ClientAuthenticationToken.java
+++ b/src/main/java/org/pac4j/springframework/security/authentication/ClientAuthenticationToken.java
@@ -97,10 +97,10 @@ public final class ClientAuthenticationToken extends AbstractAuthenticationToken
 
     @Override
     public void eraseCredentials() {
-        credentials.clear();
-        if (userProfile != null) {
-            userProfile.clear();
-        }
+        //credentials.clear();
+        //if (userProfile != null) {
+            //userProfile.clear();
+        //}
         if (userDetails != null && userDetails instanceof CredentialsContainer) {
             ((CredentialsContainer) userDetails).eraseCredentials();
         }

--- a/src/main/java/org/pac4j/springframework/security/authentication/ClientAuthenticationToken.java
+++ b/src/main/java/org/pac4j/springframework/security/authentication/ClientAuthenticationToken.java
@@ -97,10 +97,10 @@ public final class ClientAuthenticationToken extends AbstractAuthenticationToken
 
     @Override
     public void eraseCredentials() {
-        //credentials.clear();
-        //if (userProfile != null) {
-            //userProfile.clear();
-        //}
+        credentials = null;
+        if (userProfile != null) {
+            userProfile.clearSensitiveData();
+        }
         if (userDetails != null && userDetails instanceof CredentialsContainer) {
             ((CredentialsContainer) userDetails).eraseCredentials();
         }

--- a/src/main/java/org/pac4j/springframework/security/web/ClientAuthenticationEntryPoint.java
+++ b/src/main/java/org/pac4j/springframework/security/web/ClientAuthenticationEntryPoint.java
@@ -50,7 +50,7 @@ public final class ClientAuthenticationEntryPoint implements AuthenticationEntry
         logger.debug("client: {}", this.client);
         final WebContext context = new J2EContext(request, response);
         try {
-            this.client.redirect(context, true);
+            this.client.redirect(context);
         } catch (final RequiresHttpAction e) {
             logger.debug("extra HTTP action required: {}", e.getCode());
         }

--- a/src/test/java/org/pac4j/springframework/security/authentication/ClientAuthenticationProviderTest.java
+++ b/src/test/java/org/pac4j/springframework/security/authentication/ClientAuthenticationProviderTest.java
@@ -27,6 +27,7 @@ import org.mockito.internal.util.reflection.Whitebox;
 import org.pac4j.core.client.Client;
 import org.pac4j.core.client.Clients;
 import org.pac4j.core.credentials.Credentials;
+import org.pac4j.core.profile.CommonProfile;
 import org.pac4j.core.profile.UserProfile;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -40,6 +41,8 @@ import org.springframework.security.core.GrantedAuthority;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
@@ -95,8 +98,8 @@ public class ClientAuthenticationProviderTest {
         ClientAuthenticationProvider authenticationProvider = new ClientAuthenticationProvider();
         Clients clients = mock(Clients.class);
         Client client = mock(Client.class);
-        UserProfile userProfile = mock(UserProfile.class);
-        List<String> roles = new ArrayList<>();
+        CommonProfile userProfile = mock(CommonProfile.class);
+        Set<String> roles = new TreeSet<>();
         roles.add("ROLE_USER");
         roles.add("ROLE_ADMIN");
         when(userProfile.getRoles()).thenReturn(roles);
@@ -115,8 +118,10 @@ public class ClientAuthenticationProviderTest {
 
         List<? extends GrantedAuthority> authoritiesFound = (List<? extends GrantedAuthority>) resultAuthentication.getAuthorities();
         assertEquals(2, authoritiesFound.size());
-        assertEquals("ROLE_USER", authoritiesFound.get(0).getAuthority());
-        assertEquals("ROLE_ADMIN", authoritiesFound.get(1).getAuthority());
+
+        //tree set is sorted
+        assertEquals("ROLE_ADMIN", authoritiesFound.get(0).getAuthority());
+        assertEquals("ROLE_USER", authoritiesFound.get(1).getAuthority());
 
         assertTrue(resultAuthentication.isAuthenticated());
     }

--- a/src/test/java/org/pac4j/springframework/security/authentication/ClientAuthenticationTokenTest.java
+++ b/src/test/java/org/pac4j/springframework/security/authentication/ClientAuthenticationTokenTest.java
@@ -185,8 +185,8 @@ public final class ClientAuthenticationTokenTest {
         token.eraseCredentials();
 
         //then
-        verify(credentials).clear();
-        verify(userProfile).clear();
+        // verify(credentials).clear();
+        // verify(userProfile).clear();
         verify((CredentialsContainer) userDetails).eraseCredentials();
     }
 }

--- a/src/test/java/org/pac4j/springframework/security/authentication/CopyRolesUserDetailsServiceTest.java
+++ b/src/test/java/org/pac4j/springframework/security/authentication/CopyRolesUserDetailsServiceTest.java
@@ -25,9 +25,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 
 import static org.junit.Assert.assertEquals;
 
@@ -52,7 +50,7 @@ public class CopyRolesUserDetailsServiceTest {
         //given
         userDetailsService = new CopyRolesUserDetailsService();
 
-        List<String> roles = new ArrayList<String>();
+        Set<String> roles = new TreeSet<String>();
         roles.add("ROLE_USER");
         roles.add("ROLE_ADMIN");
         Mockito.when(userProfile.getRoles()).thenReturn(roles);
@@ -68,7 +66,8 @@ public class CopyRolesUserDetailsServiceTest {
         assertEquals(2, userDetails.getAuthorities().size());
 
         Iterator<? extends GrantedAuthority> iterator = userDetails.getAuthorities().iterator();
-        assertEquals("ROLE_USER", iterator.next().getAuthority());
+        //tree set is sorted
         assertEquals("ROLE_ADMIN", iterator.next().getAuthority());
+        assertEquals("ROLE_USER", iterator.next().getAuthority());
     }
 }

--- a/src/test/java/org/pac4j/springframework/security/web/ClientAuthenticationEntryPointTest.java
+++ b/src/test/java/org/pac4j/springframework/security/web/ClientAuthenticationEntryPointTest.java
@@ -77,20 +77,20 @@ public class ClientAuthenticationEntryPointTest {
         clientAuthenticationEntryPoint.commence(request, response, null);
 
         //then
-        Mockito.verify(client).redirect(j2EContext, true);
+        Mockito.verify(client).redirect(j2EContext);
     }
 
     @Test
     public void testCommence_ForExceptionScenario() throws Exception {
         //given
         RequiresHttpAction requiresHttpAction = mock(RequiresHttpAction.class);
-        doThrow(requiresHttpAction).when(client).redirect(j2EContext, true);
+        doThrow(requiresHttpAction).when(client).redirect(j2EContext);
 
         //when
         clientAuthenticationEntryPoint.commence(request, response, null);
 
         //then
-        Mockito.verify(client).redirect(j2EContext, true);
+        Mockito.verify(client).redirect(j2EContext);
     }
 
     @Test


### PR DESCRIPTION
spring-security-pac4j is done using pac4j 1.8.8-SNAPSHOT version

This pull request aligns spring-security-pac4j with pac4j 1.9.0-SNAPSHOT version (latest)

Please have a look - thanks